### PR TITLE
Fix logging setup when log directory missing

### DIFF
--- a/dbs/log_config.py
+++ b/dbs/log_config.py
@@ -32,6 +32,13 @@ Example with dynamic naming
     logger = logging.getLogger(__name__)
 """
 
+import os
+
+# Ensure the log directory exists before configuring logging.  This
+# prevents `logging.config.dictConfig` from failing when the directory
+# is missing, such as during fresh test runs.
+os.makedirs("log", exist_ok=True)
+
 LOG_CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
## Summary
- ensure log directory exists before configuring logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_e_685417d82cb48332baa7ce9385dc5a7a