### PR TITLE
Switch to BigQuery ticker prices via config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ BASE_URL = "https://paper-api.alpaca.markets"  # Paper trading (safe for testing
 # BASE_URL = "https://api.alpaca.markets"      # Live trading (uses real money)
 WANDB_API_KEY = "your_wandb_api_key"
 MONGO_URL = "your_mongo_connection_string"
+BQ_DATASET = "your_bigquery_dataset"
+BQ_TABLE = "your_bigquery_table"
+# Path to service account JSON; leave blank to use default credentials
+BQ_SERVICE_ACCOUNT = ""
+USE_BIGQUERY_PRICES = "False"
 ```
 
 > ⚠️ **IMPORTANT**: The default configuration uses Alpaca's paper trading environment. To switch to live trading (using real money), change the BASE_URL to "https://api.alpaca.markets". Only do this once you've thoroughly tested your strategies and understand the risks involved.

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ MONGO_URL = os.getenv("MONGO_URL")
 BQ_DATASET = os.getenv("BQ_DATASET")
 BQ_TABLE = os.getenv("BQ_TABLE")
 BQ_SERVICE_ACCOUNT = os.getenv("BQ_SERVICE_ACCOUNT")
+USE_BIGQUERY_PRICES = os.getenv("USE_BIGQUERY_PRICES", "false").lower() == "true"
 
 # Check and fail explicitly if something is missing
 required_vars = {

--- a/tests/test_ranking_trading_utils.py
+++ b/tests/test_ranking_trading_utils.py
@@ -1,0 +1,87 @@
+import importlib
+import sys
+import types
+
+import pandas as pd
+
+
+def load_utils(monkeypatch, use_bq):
+    env = {
+        "API_KEY": "x",
+        "API_SECRET": "y",
+        "BASE_URL": "http://example.com",
+        "WANDB_API_KEY": "z",
+        "MONGO_URL": "mongodb://example",
+        "BQ_DATASET": "ds",
+        "BQ_TABLE": "tbl",
+        "BQ_SERVICE_ACCOUNT": "",
+        "USE_BIGQUERY_PRICES": "true" if use_bq else "false",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    bigquery_mod = types.ModuleType("google.cloud.bigquery")
+    service_account_mod = types.ModuleType("google.oauth2.service_account")
+
+    class DummyCreds:
+        @classmethod
+        def from_service_account_file(cls, path):
+            return cls()
+
+    service_account_mod.Credentials = DummyCreds
+
+    google_mod = types.ModuleType("google")
+    cloud_mod = types.ModuleType("cloud")
+    oauth_mod = types.ModuleType("oauth2")
+
+    google_mod.cloud = cloud_mod
+    google_mod.oauth2 = oauth_mod
+    cloud_mod.bigquery = bigquery_mod
+    oauth_mod.service_account = service_account_mod
+
+    dotenv_mod = types.ModuleType("dotenv")
+    dotenv_mod.load_dotenv = lambda override=True: None
+    sys.modules["dotenv"] = dotenv_mod
+
+    sys.modules["google"] = google_mod
+    sys.modules["google.cloud"] = cloud_mod
+    sys.modules["google.cloud.bigquery"] = bigquery_mod
+    sys.modules["google.oauth2"] = oauth_mod
+    sys.modules["google.oauth2.service_account"] = service_account_mod
+
+    sys.modules.pop("config", None)
+    sys.modules.pop("utilities.bigquery_utils", None)
+    sys.modules.pop("utilities.ranking_trading_utils", None)
+    import utilities.ranking_trading_utils as rtu
+
+    importlib.reload(rtu)
+    return rtu
+
+
+def test_get_latest_price_uses_yfinance(monkeypatch):
+    rtu = load_utils(monkeypatch, use_bq=False)
+
+    class FakeTicker:
+        def __init__(self, symbol):
+            self.symbol = symbol
+
+        def history(self):
+            return pd.DataFrame({"Close": [12.34]})
+
+    monkeypatch.setattr(rtu.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr(
+        rtu, "fetch_latest_prices_bq", lambda: (_ for _ in ()).throw(AssertionError())
+    )
+
+    assert rtu.get_latest_price("AAPL") == 12.34
+
+
+def test_get_latest_price_uses_bigquery(monkeypatch):
+    rtu = load_utils(monkeypatch, use_bq=True)
+
+    monkeypatch.setattr(rtu, "fetch_latest_prices_bq", lambda: {"AAPL": 55.0})
+    monkeypatch.setattr(
+        rtu.yf, "Ticker", lambda *a, **k: (_ for _ in ()).throw(AssertionError())
+    )
+
+    assert rtu.get_latest_price("AAPL") == 55.0

--- a/utilities/ranking_trading_utils.py
+++ b/utilities/ranking_trading_utils.py
@@ -1,24 +1,19 @@
 import heapq
-import json
 import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.request import urlopen
-import pandas as pd
 
+import pandas as pd
+import pandas_market_calendars as mcal
 import yfinance as yf
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.requests import MarketOrderRequest
 from pymongo import MongoClient
 
-import pandas as pd
-import pandas_market_calendars as mcal
-from datetime import datetime
-import pytz
-
+from config import USE_BIGQUERY_PRICES
 from control import stop_loss, take_profit
-from strategies.talib_indicators import (
+from strategies.talib_indicators import (  # LINEARREG_indicator,; MINUS_DI_indicator,; PLUS_DI_indicator,
     AD_indicator,
     ADOSC_indicator,
     ADX_indicator,
@@ -106,7 +101,6 @@ from strategies.talib_indicators import (
     HT_TRENDMODE_indicator,
     KAMA_indicator,
     LINEARREG_ANGLE_indicator,
-    # LINEARREG_indicator,
     LINEARREG_INTERCEPT_indicator,
     LINEARREG_SLOPE_indicator,
     MA_indicator,
@@ -119,12 +113,10 @@ from strategies.talib_indicators import (
     MFI_indicator,
     MIDPOINT_indicator,
     MIDPRICE_indicator,
-    # MINUS_DI_indicator,
     MINUS_DM_indicator,
     MOM_indicator,
     NATR_indicator,
     OBV_indicator,
-    # PLUS_DI_indicator,
     PLUS_DM_indicator,
     PPO_indicator,
     ROC_indicator,
@@ -152,6 +144,7 @@ from strategies.talib_indicators import (
     WILLR_indicator,
     WMA_indicator,
 )
+from utilities.bigquery_utils import fetch_latest_prices_bq
 
 sys.path.append("..")
 
@@ -300,7 +293,7 @@ statistical_functions = [
     VAR_indicator,
 ]
 
-strategies = ( 
+strategies = (
     volume_indicators
     + overlap_studies
     + momentum_indicators
@@ -314,63 +307,71 @@ strategies = (
 
 def market_status() -> str:
     """Determines the current status of the market (open, closed, or early hours)."""
-    nyse = mcal.get_calendar('NYSE')
-    now = pd.Timestamp.now(tz='US/Eastern')
+    nyse = mcal.get_calendar("NYSE")
+    now = pd.Timestamp.now(tz="US/Eastern")
     sched = nyse.schedule(start_date=now.date(), end_date=now.date())
 
     if sched.empty:
-        return 'closed'
+        return "closed"
 
-    today_schedule = sched.iloc[0]  # Safe access without worrying about index tz mismatch
-    open_time = today_schedule['market_open']
-    close_time = today_schedule['market_close']
+    today_schedule = sched.iloc[
+        0
+    ]  # Safe access without worrying about index tz mismatch
+    open_time = today_schedule["market_open"]
+    close_time = today_schedule["market_close"]
     pre_open = open_time - pd.Timedelta(hours=5.5)
 
     if open_time <= now <= close_time:
-        return 'open'
+        return "open"
     if pre_open <= now < open_time:
-        return 'early_hours'
-    return 'closed'
-
+        return "early_hours"
+    return "closed"
 
 
 def get_latest_price(ticker: str) -> float | None:
+    """Return the latest closing price for ``ticker``.
+
+    The source of prices is determined by the ``USE_BIGQUERY_PRICES`` setting
+    in :mod:`config`. When enabled, prices are fetched from BigQuery via
+    :func:`utilities.bigquery_utils.fetch_latest_prices_bq`; otherwise ``yfinance``
+    is used.
     """
-        Fetches the latest closing price for a given stock ticker from Yahoo Finance.
 
-        Args:
-            ticker (str): The stock ticker symbol (e.g., 'AAPL', 'MSFT').
+    if USE_BIGQUERY_PRICES:
+        try:
+            prices = fetch_latest_prices_bq()
+            return prices.get(ticker)
+        except Exception as exc:  # pragma: no cover - network-dependent
+            logging.error(f"Error fetching price from BigQuery for {ticker}: {exc}")
+            return None
 
-        Returns:
-            float: The latest closing price, rounded to 2 decimal places.
-                   Returns None if there is an error fetching the price.
-
-        Raises:
-            Exception: Logs any exceptions encountered during the process.
-
-    """
     try:
         ticker_yahoo = yf.Ticker(ticker)
         data = ticker_yahoo.history()
-
         return round(data["Close"].iloc[-1], 2)
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - network-dependent
         logging.error(f"Error fetching latest price for {ticker}: {e}")
         return None
 
 
-def place_order(trading_client: object, symbol: str, side: OrderSide, quantity: float, mongo_client: MongoClient) -> object:
+def place_order(
+    trading_client: object,
+    symbol: str,
+    side: OrderSide,
+    quantity: float,
+    mongo_client: MongoClient,
+) -> object:
     """Places a market order for a given symbol and logs the trade details.
 
-        Args:
-            trading_client: The Alpaca trading client.
-            symbol (str): The symbol to trade.
-            side (OrderSide): The side of the order (buy or sell).
-            quantity (float): The quantity to trade.
-            mongo_client: The MongoDB client.
+    Args:
+        trading_client: The Alpaca trading client.
+        symbol (str): The symbol to trade.
+        side (OrderSide): The side of the order (buy or sell).
+        quantity (float): The quantity to trade.
+        mongo_client: The MongoDB client.
 
-        Returns:
-            Order: The order object returned by the Alpaca API.
+    Returns:
+        Order: The order object returned by the Alpaca API.
 
     """
     market_order_data = MarketOrderRequest(
@@ -418,31 +419,32 @@ def place_order(trading_client: object, symbol: str, side: OrderSide, quantity: 
 
     return order
 
+
 def update_ranks(client: MongoClient, logger: logging.Logger) -> None:
     """Updates the ranking of trading strategies based on their performance.
-        This function calculates a score for each strategy based on its total points,
-        portfolio value, successful trades, and failed trades. It then ranks the
-        strategies based on this score and stores the ranking in the 'rank' collection.
-        It also clears the historical database after updating the ranks.
-        Args:
-            client (MongoClient): A MongoClient instance connected to the MongoDB database.
-                The client should have access to the 'trading_simulator' and
-                'HistoricalDatabase' databases.
-        Returns:
-            None. The function updates the 'rank' collection in the
-            'trading_simulator' database and clears the 'HistoricalDatabase' database.
-        Raises:
-            pymongo.errors.PyMongoError: If there is an error interacting with the
-                MongoDB database.
+    This function calculates a score for each strategy based on its total points,
+    portfolio value, successful trades, and failed trades. It then ranks the
+    strategies based on this score and stores the ranking in the 'rank' collection.
+    It also clears the historical database after updating the ranks.
+    Args:
+        client (MongoClient): A MongoClient instance connected to the MongoDB database.
+            The client should have access to the 'trading_simulator' and
+            'HistoricalDatabase' databases.
+    Returns:
+        None. The function updates the 'rank' collection in the
+        'trading_simulator' database and clears the 'HistoricalDatabase' database.
+    Raises:
+        pymongo.errors.PyMongoError: If there is an error interacting with the
+            MongoDB database.
 
     """
     pts_coll = client.trading_simulator.points_tally
     rank_coll = client.trading_simulator.rank
     holdings_coll = client.trading_simulator.algorithm_holdings
-   
+
     # Clear existing ranks
     rank_coll.delete_many({})
-    
+
     # Clear historical database
     client.HistoricalDatabase.HistoricalDatabase.delete_many({})
 
@@ -453,29 +455,33 @@ def update_ranks(client: MongoClient, logger: logging.Logger) -> None:
         # Skip test strategies
         if strategy_name in ["test", "test_strategy"]:
             continue
-        
+
         pts_doc = pts_coll.find_one({"strategy": strategy_name})
         if not pts_doc:
             logger.warning(f"No points document for strategy {strategy_name}")
             total_points = 0
         else:
             total_points = pts_doc["total_points"]
-        
+
         performance_diff = doc.get("successful_trades", 0) - doc.get("failed_trades", 0)
-        
+
         if total_points > 0:
             # Good performing strategies: use total_points*2 + portfolio_value as score
-            score = (total_points * 2 + doc["portfolio_value"], 
-                    performance_diff,
-                    doc["amount_cash"],
-                    strategy_name)
+            score = (
+                total_points * 2 + doc["portfolio_value"],
+                performance_diff,
+                doc["amount_cash"],
+                strategy_name,
+            )
         else:
             # Poor performing strategies: use portfolio_value as score
-            score = (doc["portfolio_value"],
-                    performance_diff,
-                    doc["amount_cash"],
-                    strategy_name)
-                    
+            score = (
+                doc["portfolio_value"],
+                performance_diff,
+                doc["amount_cash"],
+                strategy_name,
+            )
+
         heapq.heappush(heap, score)
 
     rank = 1
@@ -483,6 +489,6 @@ def update_ranks(client: MongoClient, logger: logging.Logger) -> None:
         _, _, _, strategy = heapq.heappop(heap)
         rank_coll.insert_one({"strategy": strategy, "rank": rank})
         rank += 1
-        
+
     logger.info("Successfully updated ranks")
     logger.info("Successfully cleared historical database")


### PR DESCRIPTION
## Summary
- add `USE_BIGQUERY_PRICES` in `config.py`
- document `USE_BIGQUERY_PRICES` and BigQuery settings
- support BigQuery pricing in `get_latest_price`
- add tests for BigQuery/yfinance switch

## Testing
- `pre-commit run --files config.py utilities/ranking_trading_utils.py README.md tests/test_ranking_trading_utils.py`
- `pytest -q` *(fails: ProxyError when fetching yfinance data)*

------
https://chatgpt.com/codex/tasks/task_e_68556cd94b3483328fddbf2d078f8468