### PR TITLE
Add BigQuery service account parsing

### DIFF
--- a/tests/test_bigquery_integration.py
+++ b/tests/test_bigquery_integration.py
@@ -1,0 +1,39 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+
+def load_real_bigquery_utils(monkeypatch):
+    # ensure required variables for config
+    defaults = {
+        "API_KEY": "x",
+        "API_SECRET": "y",
+        "BASE_URL": "http://example.com",
+        "WANDB_API_KEY": "z",
+        "MONGO_URL": "mongodb://example",
+    }
+    for k, v in defaults.items():
+        monkeypatch.setenv(k, v)
+    sys.modules.pop("config", None)
+    sys.modules.pop("utilities.bigquery_utils", None)
+    import utilities.bigquery_utils as bq
+
+    importlib.reload(bq)
+    return bq
+
+
+@pytest.mark.integration
+def test_fetch_latest_prices_real(monkeypatch):
+    if not (
+        os.getenv("BQ_DATASET")
+        and os.getenv("BQ_TABLE")
+        and os.getenv("BQ_SERVICE_ACCOUNT")
+    ):
+        pytest.skip("BigQuery environment not configured")
+
+    bq = load_real_bigquery_utils(monkeypatch)
+
+    prices = bq.fetch_latest_prices_bq()
+    assert isinstance(prices, dict)


### PR DESCRIPTION
## Summary
- support JSON strings for `BQ_SERVICE_ACCOUNT`
- simplify BigQuery integration test now that credentials can be inline JSON
- cover JSON credentials in unit tests

## Testing
- `python -m pip install --user -r requirements.txt --no-deps`
- `python -m pip install --user -r requirements-dev.txt --no-deps`
- `pytest -q tests/test_bigquery_utils.py tests/test_bigquery_integration.py`
- `pre-commit run --files utilities/bigquery_utils.py tests/test_bigquery_integration.py tests/test_bigquery_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685583de3fe88332a4448dca45422837