### PR TITLE
Fix type hint for BigQuery utils

### DIFF
--- a/utilities/bigquery_utils.py
+++ b/utilities/bigquery_utils.py
@@ -86,7 +86,7 @@ def fetch_latest_prices_bq() -> Dict[str, float]:
         return _cached_prices
 
 
-def get_latest_price_bq(ticker: str) -> float | None:
+def get_latest_price_bq(ticker: str) -> Optional[float]:
     """Return the latest price for ``ticker`` using BigQuery cache."""
     prices = fetch_latest_prices_bq()
     return prices.get(ticker)


### PR DESCRIPTION
## Summary
- fix `get_latest_price_bq` type hint for Python <3.10 compatibility

## Testing
- `pre-commit run --files utilities/bigquery_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68571e3f6dd88332ad398fdd3f40fc26