### PR TITLE
Add pandas_market_calendars requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ alpaca-py
 yfinance[nospam]
 scipy
 pandas
+pandas_market_calendars
 cython
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary
- restore use of pandas_market_calendars in ranking utilities
- add the library to requirements

## Testing
- `pre-commit run --files requirements.txt utilities/ranking_trading_utils.py`
- `pytest -q` *(fails: ProxyError fetching Yahoo Finance; KeyboardInterrupt on google API)*

------
https://chatgpt.com/codex/tasks/task_e_68571ba9a87c833289eee77f65831bcc