### PR TITLE
Fix Python type annotation for compatibility

### DIFF
--- a/utilities/ranking_trading_utils.py
+++ b/utilities/ranking_trading_utils.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import pandas_market_calendars as mcal
@@ -328,7 +329,7 @@ def market_status() -> str:
     return "closed"
 
 
-def get_latest_price(ticker: str) -> float | None:
+def get_latest_price(ticker: str) -> Optional[float]:
     """
     Fetches the latest closing price for a given stock ticker from Yahoo Finance.
 


### PR DESCRIPTION
## Summary
- import `Optional` typing and use it for `get_latest_price`
- run pre-commit hooks

## Testing
- `pre-commit run --files utilities/ranking_trading_utils.py`
- `pytest` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68572274c8fc8332beac9b776ca5d83c